### PR TITLE
 [#9] feat:category service 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/sparta/orderservice/category/application/service/CategoryServiceV1.java
+++ b/src/main/java/com/sparta/orderservice/category/application/service/CategoryServiceV1.java
@@ -1,0 +1,85 @@
+package com.sparta.orderservice.category.application.service;
+
+import com.sparta.orderservice.category.domain.entity.Category;
+import com.sparta.orderservice.category.domain.repository.CategoryRepository;
+import com.sparta.orderservice.category.presentation.dto.request.ReqCategoryDtoV1;
+import com.sparta.orderservice.category.presentation.dto.request.ReqCategoryUpdateDtoV1;
+import com.sparta.orderservice.category.presentation.dto.response.ResCategoryDtoV1;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CategoryServiceV1 {
+
+    private final CategoryRepository categoryRepository;
+
+    public ResCategoryDtoV1 createCategory(ReqCategoryDtoV1 request) {
+
+        // 카테고리 존재 여부
+        existCategoryName(request.getName());
+
+        // todo: 수정필요
+        Category category = Category.ofNewCategory(request.getName(), null);
+
+        categoryRepository.save(category);
+
+        return convertResCategoryDto(category);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ResCategoryDtoV1> getCategoryList() {
+
+        List<Category> categoryList = categoryRepository.findAll();
+        List<ResCategoryDtoV1> resCategoryDtoV1List = new ArrayList<>();
+
+        for(Category category : categoryList) {
+            resCategoryDtoV1List.add(convertResCategoryDto(category));
+        }
+
+        return resCategoryDtoV1List;
+    }
+
+    @Transactional(readOnly = true)
+    public ResCategoryDtoV1 getCategory(UUID categoryId) {
+        Category category = categoryRepository.findById(categoryId).orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+
+        return convertResCategoryDto(category);
+    }
+
+    public ResCategoryDtoV1 updateCategory(UUID categoryId, ReqCategoryUpdateDtoV1 request) {
+
+        existCategoryName(request.getName());
+
+        Category category = categoryRepository.findById(categoryId).orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+
+        // todo: 수정필요
+        category.update(request.getName(), null);
+
+        return convertResCategoryDto(category);
+    }
+
+    public void deleteCategory(UUID categoryId) {
+        Category category = categoryRepository.findById(categoryId).orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+
+        // todo: 수정필요
+        category.delete(null);
+    }
+
+    private ResCategoryDtoV1 convertResCategoryDto(Category category) {
+        return new ResCategoryDtoV1(category.getCategoryId(), category.getName());
+    }
+
+    private void existCategoryName(String name) {
+        if(categoryRepository.existsByName(name)) {
+            throw new IllegalArgumentException("이미 존재하는 카테고리 입니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/sparta/orderservice/category/domain/entity/Category.java
+++ b/src/main/java/com/sparta/orderservice/category/domain/entity/Category.java
@@ -57,7 +57,6 @@ public class Category {
 
     public void update(String name, Long updatedBy) {
         this.name = name;
-        this.updatedAt = LocalDateTime.now();
         this.updatedBy = updatedBy;
     }
 

--- a/src/main/java/com/sparta/orderservice/category/domain/entity/Category.java
+++ b/src/main/java/com/sparta/orderservice/category/domain/entity/Category.java
@@ -46,15 +46,13 @@ public class Category {
         this.updatedAt = LocalDateTime.now();
     }
 
-    private Category(String name, Long createdBy, Long updatedBy, Long deletedBy) {
+    private Category(String name, Long createdBy) {
         this.name = name;
         this.createdBy = createdBy;
-        this.updatedBy = updatedBy;
-        this.deletedBy = deletedBy;
     }
 
     public static Category ofNewCategory(String name, Long createdBy){
-        return new Category(name, createdBy, null, null);
+        return new Category(name, createdBy);
     }
 
     public void update(String name, Long updatedBy) {

--- a/src/main/java/com/sparta/orderservice/category/domain/entity/Category.java
+++ b/src/main/java/com/sparta/orderservice/category/domain/entity/Category.java
@@ -1,0 +1,72 @@
+package com.sparta.orderservice.category.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID categoryId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
+    @Column(nullable = false)
+    private Long createdBy;
+
+    private Long updatedBy;
+
+    private Long deletedBy;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    private Category(String name, Long createdBy, Long updatedBy, Long deletedBy) {
+        this.name = name;
+        this.createdBy = createdBy;
+        this.updatedBy = updatedBy;
+        this.deletedBy = deletedBy;
+    }
+
+    public static Category ofNewCategory(String name, Long createdBy){
+        return new Category(name, createdBy, null, null);
+    }
+
+    public void update(String name, Long updatedBy) {
+        this.name = name;
+        this.updatedAt = LocalDateTime.now();
+        this.updatedBy = updatedBy;
+    }
+
+    public void delete(Long deletedBy) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = deletedBy;
+    }
+
+
+}

--- a/src/main/java/com/sparta/orderservice/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/orderservice/category/domain/repository/CategoryRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.orderservice.category.domain.repository;
+
+import com.sparta.orderservice.category.domain.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface CategoryRepository extends JpaRepository<Category, UUID> {
+
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/sparta/orderservice/category/presentation/controller/CategoryControllerV1.java
+++ b/src/main/java/com/sparta/orderservice/category/presentation/controller/CategoryControllerV1.java
@@ -1,9 +1,11 @@
 package com.sparta.orderservice.category.presentation.controller;
 
+import com.sparta.orderservice.category.application.service.CategoryServiceV1;
 import com.sparta.orderservice.category.presentation.dto.request.ReqCategoryDtoV1;
 import com.sparta.orderservice.category.presentation.dto.request.ReqCategoryUpdateDtoV1;
 import com.sparta.orderservice.category.presentation.dto.response.ResCategoryDtoV1;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,41 +15,42 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/v1/categorys")
+@RequiredArgsConstructor
 public class CategoryControllerV1 {
+
+    private final CategoryServiceV1 categoryService;
 
     @PostMapping
     public ResponseEntity<ResCategoryDtoV1> createCategory(@RequestBody @Valid ReqCategoryDtoV1 request) {
-
-        ResCategoryDtoV1 response = new ResCategoryDtoV1(UUID.randomUUID(), request.getName());
+        ResCategoryDtoV1 response = categoryService.createCategory(request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @GetMapping
     public ResponseEntity<List<ResCategoryDtoV1>> getCategoryList() {
-        ResCategoryDtoV1 response = new ResCategoryDtoV1(UUID.randomUUID(), "한식");
-
-        List<ResCategoryDtoV1> dtoList = List.of(response);
+        List<ResCategoryDtoV1> dtoList = categoryService.getCategoryList();
 
         return ResponseEntity.ok(dtoList);
     }
 
     @GetMapping("/{categoryId}")
     public ResponseEntity<ResCategoryDtoV1> getCategory(@PathVariable UUID categoryId) {
-        ResCategoryDtoV1 response = new ResCategoryDtoV1(categoryId, "한식");
+        ResCategoryDtoV1 response = categoryService.getCategory(categoryId);
 
         return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/{categoryId}")
     public ResponseEntity<ResCategoryDtoV1> updateCategory(@PathVariable UUID categoryId, @RequestBody @Valid ReqCategoryUpdateDtoV1 request) {
-        ResCategoryDtoV1 response = new ResCategoryDtoV1(categoryId, request.getName());
+        ResCategoryDtoV1 response = categoryService.updateCategory(categoryId, request);
 
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{categoryId}")
     public ResponseEntity<Void> deleteCategory(@PathVariable UUID categoryId) {
+        categoryService.deleteCategory(categoryId);
 
         return ResponseEntity.ok().build();
     }

--- a/src/test/java/com/sparta/orderservice/category/application/service/CategoryServiceV1Test.java
+++ b/src/test/java/com/sparta/orderservice/category/application/service/CategoryServiceV1Test.java
@@ -1,0 +1,154 @@
+package com.sparta.orderservice.category.application.service;
+
+import com.sparta.orderservice.category.domain.entity.Category;
+import com.sparta.orderservice.category.domain.repository.CategoryRepository;
+import com.sparta.orderservice.category.presentation.dto.request.ReqCategoryDtoV1;
+import com.sparta.orderservice.category.presentation.dto.request.ReqCategoryUpdateDtoV1;
+import com.sparta.orderservice.category.presentation.dto.response.ResCategoryDtoV1;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceV1Test {
+
+    @Mock
+    CategoryRepository categoryRepository;
+
+    @InjectMocks
+    CategoryServiceV1 categoryService;
+
+    Category category;
+    UUID categoryId;
+
+    @BeforeEach
+    void setUp() {
+        category = Category.ofNewCategory("한식", 1L);
+        categoryId = UUID.randomUUID();
+        ReflectionTestUtils.setField(category, "categoryId", categoryId);
+    }
+
+    @Test
+    @DisplayName("카테고리 생성")
+    void createCategory() {
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("중식");
+        categoryService.createCategory(request);
+
+        verify(categoryRepository, Mockito.times(1)).save(Mockito.any(Category.class));
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 - 이름 중복")
+    void createCategory_conflict() {
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("중식");
+        when(categoryRepository.existsByName(request.getName())).thenReturn(true);
+
+        assertThrows(IllegalArgumentException.class, () ->
+                categoryService.createCategory(request)
+        );
+
+        verify(categoryRepository, Mockito.never()).save(Mockito.any(Category.class));
+    }
+
+
+    @Test
+    @DisplayName("카테고리 리스트 조회")
+    void getCategoryList() {
+        when(categoryRepository.findAll()).thenReturn(List.of(category));
+
+        categoryService.getCategoryList();
+
+        verify(categoryRepository, Mockito.times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("카테고리 조회")
+    void getCategory() {
+        when(categoryRepository.findById(Mockito.any(UUID.class))).thenReturn(Optional.of(category));
+
+        categoryService.getCategory(categoryId);
+
+        verify(categoryRepository, Mockito.times(1)).findById(Mockito.any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("카테고리 조회 - 존재하지 않음")
+    void getCategory_not_found() {
+        when(categoryRepository.findById(Mockito.any())).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () ->
+                categoryService.getCategory(categoryId)
+        );
+
+        verify(categoryRepository, Mockito.times(1)).findById(Mockito.any());
+    }
+
+    @Test
+    @DisplayName("카테고리 수정")
+    void updateCategory() {
+        ReqCategoryUpdateDtoV1 request = new ReqCategoryUpdateDtoV1("양식");
+        when(categoryRepository.findById(Mockito.any())).thenReturn(Optional.of(category));
+
+        ResCategoryDtoV1 response = categoryService.updateCategory(categoryId, request);
+
+
+        assertAll(() -> {
+            assertEquals("양식", category.getName());
+            assertNotNull(category.getUpdatedAt());
+        });
+    }
+
+    @Test
+    @DisplayName("카테고리 수정 - 존재하지 않음")
+    void updateCategory_not_found() {
+        ReqCategoryUpdateDtoV1 request = new ReqCategoryUpdateDtoV1("양식");
+        when(categoryRepository.findById(Mockito.any())).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () ->
+            categoryService.updateCategory(categoryId, request)
+        );
+
+        assertNull(category.getUpdatedAt());
+
+    }
+
+    @Test
+    @DisplayName("카테고리 수정 - 이름 중복")
+    void updateCategory_conflict() {
+        ReqCategoryUpdateDtoV1 request = new ReqCategoryUpdateDtoV1("양식");
+        when(categoryRepository.existsByName(request.getName())).thenReturn(true);
+
+        assertThrows(IllegalArgumentException.class, () ->
+            categoryService.updateCategory(categoryId, request)
+        );
+        assertNull(category.getUpdatedAt());
+
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제")
+    void deleteCategory() {
+        when(categoryRepository.findById(Mockito.any())).thenReturn(Optional.of(category));
+        categoryService.deleteCategory(categoryId);
+
+        assertAll(() -> {
+            assertNotNull(category.getDeletedAt());
+        });
+    }
+}

--- a/src/test/java/com/sparta/orderservice/category/domain/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/sparta/orderservice/category/domain/repository/CategoryRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.sparta.orderservice.category.domain.repository;
+
+import com.sparta.orderservice.category.domain.entity.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class CategoryRepositoryTest {
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    private TestEntityManager manager;
+
+    Category category;
+
+    @BeforeEach
+    void setUp() {
+        category = Category.ofNewCategory("한식", 1L);
+
+        manager.persist(category);
+        manager.flush();
+        manager.clear();
+    }
+
+    @Test
+    @DisplayName("카테고리 존재")
+    void existsByName_true() {
+        boolean exist = categoryRepository.existsByName("한식");
+
+        assertTrue(exist);
+    }
+
+    @Test
+    @DisplayName("카테고리 존재하지 않음")
+    void existsByName_false() {
+        boolean exist = categoryRepository.existsByName("양식");
+
+        assertFalse(exist);
+    }
+}

--- a/src/test/java/com/sparta/orderservice/category/domain/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/sparta/orderservice/category/domain/repository/CategoryRepositoryTest.java
@@ -27,8 +27,7 @@ class CategoryRepositoryTest {
     void setUp() {
         category = Category.ofNewCategory("한식", 1L);
 
-        manager.persist(category);
-        manager.flush();
+        manager.persistAndFlush(category);
         manager.clear();
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=PostgreSQL


### PR DESCRIPTION
## 🔘 Part  
- 카테고리 관리 서비스 (`CategoryServiceV1`)  
- **기능:** 카테고리 등록 / 조회 / 수정 / 삭제  

---

## 🔎 작업 내용  

### ✅ 구현된 기능
- `createCategory()`  
  - 카테고리명 중복 검사 (`existCategoryName`)  
  - 새로운 카테고리 생성 및 저장  
- `getCategoryList()`  
  - 전체 카테고리 목록 조회  
- `getCategory()`  
  - 특정 카테고리 ID로 단건 조회  
- `updateCategory()`  
  - 카테고리명 변경 (중복 검사 포함)  
- `deleteCategory()`  
  - 카테고리 삭제 처리  

### ⚙️ 코드 상세  
- `@Transactional(readOnly = true)` 을 통한 조회 최적화  
- DTO 변환 전용 메서드 `convertResCategoryDto()` 분리  
- 중복 이름 예외 처리(`IllegalArgumentException`)로 단순 검증  

---

## ⚠️ 현재 이슈 / 개선 필요사항  

| 구분 | 내용 | 비고 |
|------|------|------|
| TODO | `Category.ofNewCategory(request.getName(), null)` → 생성자에 `createdBy` null 처리 | 추후 인증 사용자 정보 주입 필요 |
| TODO | `category.update(request.getName(), null)` → `updatedBy` null 처리 | 로그인 사용자 ID 반영 필요 |
| TODO | `category.delete(null)` → `deletedBy` null 처리 | Soft delete 시 삭제자 정보 누락 |
| 개선 | 예외 메시지를 공통화할 수 있도록 `BusinessException` 혹은 `ErrorCode` 적용 고려 | 유지보수성 향상 |

---

## 🔧 앞으로의 과제  
- 인증 사용자(`createdBy`, `updatedBy`, `deletedBy`) 정보 연동  
- 예외 처리 통합 (공통 예외 구조 적용)  
- 테스트 코드 보강 (`CategoryServiceV1Test`)  

## ➕ 이슈 링크 
- #9 
